### PR TITLE
Older Gens Proof Req Standardization & Optimization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,5 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
 end
 
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,12 +23,14 @@ GEM
       http_parser.rb (~> 0)
     ethon (0.15.0)
       ffi (>= 1.15.0)
+    eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.8.1)
     faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.1)
+    ffi (1.15.5-x64-mingw-ucrt)
     ffi (1.15.5-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -211,6 +213,8 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.16.3)
+    nokogiri (1.13.9-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.13.9-x64-mingw32)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -249,12 +253,15 @@ GEM
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
+    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (1.8.0)
     wdm (0.1.1)
+    webrick (1.7.0)
     zeitwerk (2.6.1)
 
 PLATFORMS
+  x64-mingw-ucrt
   x64-mingw32
 
 DEPENDENCIES
@@ -265,6 +272,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick
 
 BUNDLED WITH
    2.2.18

--- a/proof-guidelines/3DS/index.html
+++ b/proof-guidelines/3DS/index.html
@@ -21,7 +21,7 @@ for the above mentioned games is provided on this page.<br /><br />
   <div class="card-body card-bg">
     <p>Pokemon obtained in the above mentioned 3DS titles that meet the description of anything listed directly below need proof to trade inside the PS! Wi-Fi room.</p>
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild/Roaming/Stationary/Gift encounters:</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild & Static Encounters / Gift Redemptions:</span></p>
 
     <u>Encounters with 0 guaranteed IVs</u>
     <ul>
@@ -36,14 +36,14 @@ for the above mentioned games is provided on this page.<br /><br />
     </ul>
     <hr />
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from SOS chain encounters (SM/USUM):</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from SOS Chain Encounters (SM/USUM):</span></p>
     <ul>
       <li>5 IV+ Pok&eacute;mon</li>
       <li>Shiny Pok&eacute;mon from 1% chance SOS calls</li>
     </ul>
     <hr />
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from Friend Safari or DexNav encounters (XY/ORAS):</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Friend Safari or DexNav Encounters (XY/ORAS):</span></p>
     <ul>
       <li>5 IV+ shiny Pok&eacute;mon</li>
       <li>6 IV non-shiny Pok&eacute;mon</li>
@@ -51,7 +51,7 @@ for the above mentioned games is provided on this page.<br /><br />
     </ul>
     <hr />
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from event distributions:</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Event Distributions:</span></p>
     <u>Distributions with 0 guaranteed IVs</u>
     <ul>
       <li>4 IV+ non-shiny/shiny Pok&eacute;mon</li>
@@ -64,15 +64,16 @@ for the above mentioned games is provided on this page.<br /><br />
 
     <u>Other</u>
     <ul>
-      <li>Nicknamed Pok&eacute;mon from event distributions as a result of matching trainer information</li>
-      <li>"Sometimes shiny" shiny event Pok&eacute;mon</li>
+      <li>Nicknamed Event Pok&eacute;mon made possible by RNGing matching trainer information</li>
+      <li>"Sometimes Shiny" Shiny Event Pok&eacute;mon (e.g Lunar Magikarp)</li>
+      <li>Shiny Event Egg Pok&eacute;mon obtained via TSV hatching/trading (e.g PC Tokyo Egg Events)</li>
     </ul>
     <hr />
 
-    <p><span class="fw-bold">Shiny Pok&eacute;mon obtained from TSV hatches:</span></p>
+    <p><span class="fw-bold">Shiny Pok&eacute;mon obtained from Eggs via TSV hatching:</span></p>
     <ul>
-      <li>Pok&eacute;mon obtained through hatching a shiny Pok&eacute;mon due to matching TSV values traded between two users require proof.</li>
-      <li>TSV hatched Pok&eacute;mon must provide a screenshot of the conversation between the two users, agreeing upon a TSV hatch.</li>
+      <li>Shiny Pok&eacute;mon obtained via tarding an Egg, with the purpose of hatching it shiny by matching the Egg's ESV value to a TSV value require proof.</li>
+      <li>For TSV hatched Pok&eacute;mon you must provide a screenshot of the conversation between the two users agreeing on a TSV hatch, with the hatcher's OT visible or stated in some manner.</li>
     </ul>
   </div>
 </div><br />
@@ -83,29 +84,29 @@ for the above mentioned games is provided on this page.<br /><br />
       style="width:55px;height:55px;">
 </div>
 <hr />
-This section of the page covers how to create proof for Pok&eacute;mon obtained in Gen 6 and Gen 7 (3DS) titles. In all cases, your PS! Username <u>must</u> be visible somewhere within your proof link so that we can easily verify exactly where the
+This section of the page covers how to create proof for Pok&eacute;mon obtained in Gen 6 and Gen 7 (3DS) titles. In all cases, your <span class="fw-bold">PS! Username <u>must</u> be visible</span> somewhere within your proof link so that we can easily verify exactly where the
 Pok&eacute;mon has come from.<br /> <br />
 
 <div class="card border-dark">
   <div class="card-header" style="background-color: #7a298f;" id="3DSWild">
-    <span class="fw-bold text-light">Stationary, Wild & Gift Encounters:</span>
+    <span class="fw-bold text-light">Static & Wild Encounters / Gift & Event Redemptions:</span>
   </div>
   <div class="card-body card-bg">
-    <p><span class="fw-bold"><u>If you are using 3DS overlays or Citra for RNG abuse purposes you must provide:</u></span></p>
+    <p><span class="fw-bold"><u>If you are using 3DS overlays or Citra for RNG abuse you must provide:</u></span></p>
     <ul>
-      <li>A screenshot or picture hitting your target frame with the overlay output visible.</li><br />
-      <li>A screenshot or picture of the encounter starting (i.e the <code>“Pok&eacute;mon appeared!”</code> screen) with the output from the overlay clearly visible on-screen.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed & PID/EC can be partially
+      <li>For <span class="fw-bold"><u>Encounters</u></span>, a screenshot of you hitting your target frame (i.e at Menu hovering over the Bag for <u>Wild</u>; or Before last A press/movement for <u>Statics</u>).<br />Also a screenshot of the Encounter starting (i.e <code>“Pok&eacute;mon appeared!”</code>).<br />The Overlays must be clearly visible on-screen (if on console), or the Python Scripts be shown beside Citra, on all screenshots.</li><br />
+      <li>For <span class="fw-bold"><u>Redemptions</u></span>, a screenshot of you hitting your target frame (i.e <code>“Player received Pokemon!”</code> screen).<br />Also a screenshot after Redemption of the <u>Gift</u> or <u>Event</u> mon (i.e <code>“Pokemon was added to your party.”</code> or <code>“We look forward to serving you again!”</code> screens respectively).<br />The Overlays must be clearly visible on-screen (if on console), or the Python Scripts be shown beside Citra, on all screenshots.</li><br />
+      <li>A screenshot of the Pokemon Summary displaying both the stats and OT/TID of the Pokemon that was obtained (preferred) <u>or</u> your Trainer Card/Passport.<br />In the case of <u>Event Redemptions</u>, neither screenshot is required unless its an <u>Event that takes the Obtainer or Hatcher's OT/TID</u> (including traded Eggs), in which case either Summary or Trainer Card/Passport screenshots <u>are still required!</u></li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seeds & PID/EC can be partially
         blurred (no more than half) & hidden respectively.</li><br />
-      <li>A picture of your Trainer Card/Passport showing your OT/TID combination.</li><br />
-      <li>If 3DSTimeFinder was used to manipulate initial seed on Citra, a screenshot of the tool output that displays frame, seed, time, and date.</li>
+      <li>If <span class="fw-bold">3DSTimeFinder was used</span> to manipulate the Initial Seed on Citra, a screenshot of the tool output that displays Frame, Seed, Time & Date.</li>
     </ul>
     <hr />
 
     <p><span class="fw-bold"><u>For soft resetting and retail RNG abuse you must provide:</u></span></p>
     <ul>
-      <li>A full uncut video starting from a successful capture of your Pok&eacute;mon leading into the in-box summary screens clearly showing the stats, nature, ability, and OT/TID.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed & PID/EC can be partially
+      <li>A full uncut video starting from a successful capture or redemption of your Pok&eacute;mon leading into the in-box summary screens clearly showing the Stats, Nature, Ability, and OT/TID.</li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seeds & PID/EC can be partially
         blurred (no more than half) & hidden respectively.</li><br />
       <li>A picture of your Trainer Card/Passport showing your OT/TID combination.</li>
     </ul>
@@ -114,60 +115,34 @@ Pok&eacute;mon has come from.<br /> <br />
     <details>
       <summary><span class="fw-bold">Gen 6 Proof Examples - Encounters</span></summary>
       <ul>
-        <li><a href="https://i.imgur.com/qNkA4cp.png">Stationary Encounter</a></li>
-        <li><a href="https://i.imgur.com/fHK9PQn.png">Friend Safari (wild) Encounter</a></li>
+        <li><a href="https://imgur.com/qNkA4cp">Static Encounter</a></li>
+        <li><a href="https://imgur.com/fHK9PQn">Wild Encounter</a></li>
+        <li><a href="https://imgur.com/aQbmcLg">Static Encounter (Citra with TimeFinder)</a></li>
       </ul>
-    </details><br />
+    </details>
+    <details>
+      <summary><span class="fw-bold">Gen 6 Proof Examples - Redemptions</span></summary>
+      <ul>
+        <li><a href="https://imgur.com/8bhKwiq">Event Redemption</a></li>
+        <li><a href="https://imgur.com/a/oMoycxc">Event Egg Redemption (Made to hatch Shiny via trading)</a></li>
+        <li><a href="https://imgur.com/FYiO1Tg">Event Redemption (Citra)</a></li>
+        <li><a href="https://imgur.com/blMSrQZ">Event Redemption (Citra with TimeFinder)</a></li>
+      </ul>
+    </details>
     <details>
       <summary><span class="fw-bold">Gen 7 Proof Examples - Encounters</span></summary>
       <ul>
-        <li><a href="https://i.imgur.com/Hseayhg.png">Stationary Encounter</a></li>
+        <li><a href="https://imgur.com/Hseayhg">Static Encounter</a></li>
         <li><a href="https://imgur.com/a/kdjIL5U">Wild Encounter</a></li>
-        <li><a href="https://i.imgur.com/ysUBzr7.png">Citra Example Using Timefinder</a></li>
+        <li><a href="https://imgur.com/ysUBzr7">Static Encounter (Citra with TimeFinder)</a></li>
       </ul>
     </details>
-  </div>
-</div><br />
-
-<div class="card border-dark">
-  <div class="card-header" style="background-color: #7a298f;" id="3DSMysteryGift">
-    <span class="fw-bold text-light">Mystery Gift Redemptions:</span>
-  </div>
-  <div class="card-body card-bg">
-    <p><span class="fw-bold"><u>If you are using 3DS overlays or Citra for RNG abuse purposes you must provide:</u></span></p>
-    <ul>
-      <li>A screenshot or picture hitting your target frame at redemption with the overlay output visible (i.e <code>“You received Pok&eacute;mon”</code> screen).</li><br />
-      <li>A screenshot or picture after redemption (i.e <code>“We hope to see you again!”</code> screen or similar) with the output from the overlay clearly visible on-screen displaying the stats and IVs of the redeemed Pok&eacute;mon.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed & PID/EC can be partially
-        blurred (no more than half) & hidden respectively.</li><br />
-      <li>If the event takes your OT/TID, a picture of your Trainer Card/Passport showing your OT/TID combination.</li><br />
-      <li>If 3DSTimeFinder was used to manipulate initial seed on Citra, a screenshot of the tool output that displays frame, seed, time, and date.</li>
-    </ul>
-    <hr />
-
-    <p><span class="fw-bold"><u>For soft resetting and retail RNG abuse you must provide:</u></span></p>
-    <ul>
-      <li>A full uncut video starting from a successful redemption of your Pok&eacute;mon in a Pokecenter leading into the in-box summary screens clearly showing the stats, nature, ability, and OT/TID.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed & PID/EC can be partially
-        blurred (no more than half) & hidden respectively.</li><br />
-      <li>If the event takes your OT/TID, a picture of your Trainer Card/Passport showing your OT/TID combination.</li>
-    </ul>
-    <hr />
-
     <details>
-      <summary><span class="fw-bold">Gen 6 Proof Examples - Mystery Gift</span></summary>
+      <summary><span class="fw-bold">Gen 7 Proof Examples - Redemptions</span></summary>
       <ul>
-        <li><a href="https://i.imgur.com/8bhKwiq.png">Mystery Gift</a></li>
-        <li><a href="https://imgur.com/a/oMoycxc">Mystery Gift (With redeemers OT/TID)</a></li>
-        <li><a href="https://i.imgur.com/FYiO1Tg.png">Mystery Gift (Citra)</a></li>
-        <li><a href="https://i.imgur.com/l0cLT2B.png">Mystery Gift (Citra+Timefinder)</a></li>
-      </ul>
-    </details><br />
-    <details>
-      <summary><span class="fw-bold">Gen 7 Proof Examples - Gift/Mystery Gift</span></summary>
-      <ul>
-        <li><a href="https://i.imgur.com/Iq6yc2m.png">Mystery Gift</a></li>
-        <li><a href="https://i.imgur.com/9EIsgFU.png">In-Game Gift</a></li>
+        <li><a href="https://imgur.com/Iq6yc2m">Event Redemption</a></li>
+        <li><a href="https://imgur.com/9EIsgFU">Gift Redemption</a></li>
+        <li><a href="https://imgur.com/mNLzLI6">Gift Redemption (Citra with TimeFinder)</a></li>
       </ul>
     </details>
   </div>

--- a/proof-guidelines/DS/index.html
+++ b/proof-guidelines/DS/index.html
@@ -21,13 +21,13 @@ Only information for the above mentioned games is provided on this page.<br /><b
   <div class="card-body card-bg">
     <p>Pokemon obtained in the above mentioned DS titles that meet the description of anything listed directly below need proof to trade inside the PS! Wi-Fi room.</p>
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild/Roaming/Stationary/Gift/Egg encounters:</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild/Roaming/Static Encounters & Egg/Gift Redemptions:</span></p>
     <ul>
       <li>3 IV+ shiny Pok&eacute;mon</li>
       <li>4 IV+ non-shiny Pok&eacute;mon</li>
     </ul>
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from event distributions:</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Event Distributions:</span></p>
     <u>Distributions with 0 guaranteed IVs</u>
     <ul>
       <li>4 IV+ non-shiny/shiny Pok&eacute;mon</li>
@@ -40,16 +40,9 @@ Only information for the above mentioned games is provided on this page.<br /><b
 
     <u>Other</u>
     <ul>
-      <li>Nicknamed Pok&eacute;mon from event distributions as a result of matching trainer information</li>
-      <li>"Sometimes shiny" shiny event Pok&eacute;mon</li>
-      <li>ALL "sometimes shiny when traded" event Pok&eacute;mon from eggs. (e.g Manaphy)</li>
-    </ul>
-    <hr />
-
-    <p><span class="fw-bold">Shiny Pok&eacute;mon obtained from TSV hatches:</span></p>
-    <ul>
-      <li>Pok&eacute;mon obtained through hatching a shiny Pok&eacute;mon due to matching TSV values traded between two users require proof.</li>
-      <li>TSV hatched Pok&eacute;mon must provide a screenshot of the conversation between the two users, agreeing upon a TSV hatch.</li>
+      <li>Nicknamed Event Pok&eacute;mon made possible by RNGing matching trainer information</li>
+      <li>"Sometimes Shiny" Shiny Event Pok&eacute;mon (e.g Kyushu Trains Events)</li>
+      <li>ALL Shiny Egg Event Pok&eacute;mon made possible to hatch as shiny exclusively via trading. (e.g Manaphy Egg)</li>
     </ul>
   </div>
 </div><br />
@@ -60,93 +53,67 @@ Only information for the above mentioned games is provided on this page.<br /><b
       style="width:55px;height:55px;">
 </div>
 <hr />
-This section of the page covers how to create proof for Pok&eacute;mon obtained in Gen 4 and Gen 5 (DS) titles. In all cases, your PS! Username <u>must</u> be visible somewhere within your proof link so that we can easily verify exactly where the
+This section of the page covers how to create proof for Pok&eacute;mon obtained in Gen 4 and Gen 5 (DS) titles. In all cases, your <span class="fw-bold">PS! Username <u>must</u> be visible</span> somewhere within your proof link so that we can easily verify exactly where the
 Pok&eacute;mon has come from.<br /> <br />
 
 <div class="card border-dark">
   <div class="card-header" style="background-color: #7a298f;" id="dsWild">
-    <span class="fw-bold text-light">Stationary, Wild, Egg & Gift Encounters:</span>
+    <span class="fw-bold text-light">Static, Wild & Roaming Encounters / Egg, Gift & Event Redemptions:</span>
   </div>
   <div class="card-body card-bg">
-    <p><span class="fw-bold"><u>If you are using emulator with .lua scripts you must provide:</u></span></p>
+    <p><span class="fw-bold"><u>If using Desmume or a similar app with .lua scripts for RNG abuse you must provide:</u></span></p>
     <ul>
-      <li>A screenshot or picture hitting your target frame with the .lua script output visible.</li><br />
-      <li>A screenshot or picture of the encounter starting (i.e the <code>“Pok&eacute;mon appeared!”</code> screen for encounters & <code>"You received an egg!"</code> screen for eggs) with the output from the overlay clearly visible on-screen.</li>
-      <br />
-      <li>A screenshot or picture of the Pokemon summary, displaying the stats and OT/TID of the Pokemon that was obtained. You may use the lua script to confirm the IVs of the Pok&eacute;mon.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
-      <li>For <u>Gen 5 RNG using C-Gear</u>, show a picture or screenshot of hitting your C-gear seed.</li><br />
-      <li>For <u>roaming encounters</u>, you must show the frame being hit at the correct screen that the roamer is generated on.</li>
+      <li>For <span class="fw-bold"><u>Encounters</u></span>, a screenshot of you hitting your target frame (i.e at Sweet Scent animation for <u>Wild</u>; Before last A press or movement for <u>Statics</u>; and Before Roamer generation for <u>Roamers</u>).<br />Also a screenshot of the Encounter starting (i.e <code>“Pok&eacute;mon appeared!”</code>).<br />The lua output must be clearly visible on-screen for all screenshots.</li><br />
+      <li>For <span class="fw-bold"><u>Redemptions</u></span>, a screenshot of you hitting your target frame (i.e <code>“Take good care of it.”</code> or <code>“Do you Want it? Y/N”</code> screen for <u>Eggs & Gifts</u> & <code>“Player received Pokemon!”</code> or <code>“Good day. You must be Player.”</code> screens for <u>Events</u> in Gen 4 & Gen 5 respectively).<br />Also a screenshot after Redemption of the Egg/Gift or Event mon (i.e <code>“Player received Egg/Pokemon..”</code> or <code>“We look forward to your next visit!”</code> screens respectively).<br />The lua output must be clearly visible on-screen for all screenshots.</li><br />
+      <li>A screenshot of the Pokemon Summary displaying both the stats and OT/TID of the Pokemon that was obtained (preferred) <u>or</u> your Trainer Card.<br />In the case of <u>Event Redemptions</u>, or if an older Lua that doesn't show IVs was used, Summary screenshots <u>are mandatory!</u><br />For <u>Events that take the Obtainer or Hatcher's OT/TID</u></span> (including traded Eggs), a Trainer Card screenshot <u>is also mandatory!</u></li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your Seed and desired target frame along with any other specific configurations used.<br />Sensitive information such as Seeds & PID can be partially
+        blurred on every screenshot (no more than half!).</li><br />
+      <li>For <span class="fw-bold">Gen 5 RNG with C-Gear Seeds</span> (e.g BW Entralink RNG), a screenshot of you hitting your C-Gear Seed.</li><br />
     </ul>
+    We recommend using the most recent Luas for your RNGs so as to show & prove the IVs of your Pok&eacute;mon, in addition to the Seed in the screenshots mentioned above.<br />
     <hr />
 
     <p><span class="fw-bold"><u>For soft resetting and retail RNG abuse you must provide:</u></span></p>
     <ul>
-      <li>A full uncut video starting from a successful capture of your Pok&eacute;mon leading into the in-box summary screens clearly showing the stats, nature, ability, and OT/TID.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
+      <li>A full uncut video starting from a successful capture or redemption of your Pok&eacute;mon, leading into the in-box summary screens clearly showing the Stats, Nature, Ability, and OT/TID.</li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your Seed and desired target frame along with any other specific configurations used.<br />Sensitive information such as Seeds & PID can be partially
+        blurred on every screenshot (no more than half!).</li><br />
     </ul>
     <hr />
 
     <details>
       <summary><span class="fw-bold">Gen 4 Proof Examples - Encounters</span></summary>
       <ul>
-        <li><a href="https://imgur.com/a/I8UVEDH">Wild Encounter</a></li>
-        <li><a href="https://imgur.com/a/QkpZZMj">Static Encounter</a></li>
-        <li><a href="https://imgur.com/a/YQtb2jr">Roaming Encounter</a></li>
+        <li><a href="https://imgur.com/Lotpeq5">Wild Encounter</a></li>
+        <li><a href="https://imgur.com/bzNsDGf">Static Encounter</a></li>
+        <li><a href="https://imgur.com/yFz7eGr">Roaming Encounter</a></li>
       </ul>
-    </details><br />
+    </details>
+    <details>
+      <summary><span class="fw-bold">Gen 4 Proof Examples - Redemptions</span></summary>
+      <ul>
+        <li><a href="https://imgur.com/LTAS7S8">Gift Redemption</a></li>
+        <li><a href="https://imgur.com/KMt2Yvg">Egg Redemption</a></li>
+        <li><a href="https://imgur.com/a/Km3AOiK">Event Redemption</a></li>
+        <li><a href="https://imgur.com/a/IpRoC9w">Event Egg Redemption (Made to hatch Shiny via trading)</a></li>
+      </ul>
+    </details>
     <details>
       <summary><span class="fw-bold">Gen 5 Proof Examples - Encounters</span></summary>
       <ul>
-        <li><a href="https://i.imgur.com/7P4cP9u.png">Wild Encounter</a></li>
-        <li><a href="https://i.imgur.com/kUrNxrr.png">Entralink Encounter</a></li>
+        <li><a href="https://imgur.com/7P4cP9u">Wild Encounter</a></li>
+        <li><a href="https://imgur.com/VHYnxrH">Static Encounter</a></li>
+        <li><a href="https://imgur.com/kUrNxrr">Entralink Encounter</a></li>
         <li><a href="https://imgur.com/a/cnJcSgv">Roaming Encounter</a></li>
-        <li><a href="https://i.imgur.com/DHDId5c.png">Egg RNG Example</a></li>
       </ul>
     </details>
-  </div>
-</div><br />
-
-<div class="card border-dark">
-  <div class="card-header" style="background-color: #7a298f;" id="DSMysteryGift">
-    <span class="fw-bold text-light">Mystery Gift Redemptions:</span>
-  </div>
-  <div class="card-body card-bg">
-    <p><span class="fw-bold"><u>If you are using emulator with .lua scripts you must provide:</u></span></p>
-    <ul>
-      <li>A screenshot or picture hitting your target frame with the .lua script output visible.</li><br />
-      <li>A screenshot or picture after redemption (i.e <code>“You received a Pok&eacute;mon!”</code> screen or similar) with the output from the lua script clearly visible on-screen displaying the stats and IVs of the redeemed Pok&eacute;mon.</li>
-      <br />
-      <li>A screenshot or picture of the Pokemon summary, displaying the stats and OT/TID of the Pokemon that was obtained. You may use the lua script to confirm the IVs of the Pok&eacute;mon.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
-      <li>If the event takes your OT/TID, a picture of your Trainer Card showing your OT/TID combination. This includes event eggs that inherit the OT/TID from the hatcher.</li><br />
-    </ul>
-    <hr />
-
-    <p><span class="fw-bold"><u>For soft resetting and retail RNG abuse you must provide:</u></span></p>
-    <ul>
-      <li>A full uncut video starting from a successful redemption of your Pok&eacute;mon in a Pokecenter leading into the in-box summary screens clearly showing the stats, nature, ability, and OT/TID.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
-      <li>If the event takes your OT/TID, a picture of your Trainer Card showing your OT/TID combination. This includes event eggs that inherit the OT/TID from the hatcher.</li>
-    </ul>
-    <hr />
-
     <details>
-      <summary><span class="fw-bold">Gen 4 Proof Examples - Mystery Gift</span></summary>
+      <summary><span class="fw-bold">Gen 5 Proof Examples - Redemptions</span></summary>
       <ul>
-        <li><a href="https://imgur.com/a/Km3AOiK">Event Redemption</a></li>
-        <li><a href="https://imgur.com/a/IpRoC9w">Event Egg Redemption</a></li>
-      </ul>
-    </details><br />
-    <details>
-      <summary><span class="fw-bold">Gen 5 Proof Examples - Mystery Gift</span></summary>
-      <ul>
+        <li><a href="https://imgur.com/JYX9qvT">Gift Redemption</a></li>
+        <li><a href="https://imgur.com/DHDId5c">Egg Redemption</a></li>
         <li><a href="https://imgur.com/a/dvFm1To">Event Redemption</a></li>
-        <li><a href="https://imgur.com/a/oZixyZ5">Event Egg Redemption</a></li>
+        <li><a href="https://imgur.com/a/oZixyZ5">Event Egg Redemption (Made to hatch Shiny via trading)</a></li>
       </ul>
     </details>
   </div>

--- a/proof-guidelines/GBA/index.html
+++ b/proof-guidelines/GBA/index.html
@@ -10,7 +10,7 @@ permalink: /proof-guidelines/gba/
 </div>
 <hr />
 
-This page contains information and examples for how to create proof for your Pok&eacute;mon in <span class="fw-bold">Ruby/Sapphire/Emerald & Fire Red/Leaf Green</span> to an acceptable standard for general trading in PS! Wi-Fi. Only information for
+This page contains information and examples on how to create proof for your Pok&eacute;mon in <span class="fw-bold">Ruby/Sapphire/Emerald & Fire Red/Leaf Green</span> to an acceptable standard for general trading in PS! Wi-Fi. Only information for
 the above mentioned games is provided on this page.<br /><br />
 
 <div class="card border-dark">
@@ -21,19 +21,13 @@ the above mentioned games is provided on this page.<br /><br />
   <div class="card-body card-bg">
     <p>Pokemon obtained in the above mentioned GBA titles that meet the description of anything listed directly below need proof to trade inside the PS! Wi-Fi room.</p>
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild/Roaming/Stationary/Gift encounters:</span></p>
-
-    <u>Encounters with 0 guaranteed IVs</u>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild/Roaming/Static Encounters & Egg/Gift Redemptions:</span></p>
     <ul>
       <li>3 IV+ shiny Pok&eacute;mon</li>
       <li>4 IV+ non-shiny Pok&eacute;mon</li>
     </ul>
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from eggs:</span></p>
-    <ul>
-      <li>3 IV+ shiny Pok&eacute;mon</li>
-      <li>4 IV+ non-shiny Pok&eacute;mon</li>
-    </ul>
+
   </div>
 </div><br />
 
@@ -43,30 +37,30 @@ the above mentioned games is provided on this page.<br /><br />
       style="width:55px;height:55px;">
 </div>
 <hr />
-This section of the page covers how to create proof for Pok&eacute;mon obtained in Gen 3 (GBA) titles. In all cases, your PS! Username <u>must</u> be visible somewhere within your proof link so that we can easily verify exactly where the
+This section of the page covers how to create proof for Pok&eacute;mon obtained in Gen 3 (GBA) titles. In all cases, your <span class="fw-bold">PS! Username <u>must</u> be visible</span> somewhere within your proof link so that we can easily verify exactly where the
 Pok&eacute;mon has come from.<br /> <br />
 
 <div class="card border-dark">
   <div class="card-header" style="background-color: #7a298f;" id="gbaWild">
-    <span class="fw-bold text-light">Stationary, Wild, & Gift Encounters:</span>
+    <span class="fw-bold text-light">Static, Wild & Roaming Encounters / Egg & Gift Redemptions:</span>
   </div>
   <div class="card-body card-bg">
-    <p><span class="fw-bold"><u>If you are using emulator with .lua scripts you must provide:</u></span></p>
+    <p><span class="fw-bold"><u>If using VBA or a similar app with .lua scripts for RNG abuse you must provide:</u></span></p>
     <ul>
-      <li>A screenshot or picture of the encounter starting (i.e the <code>“Pok&eacute;mon appeared!”</code> screen, with the lua output clearly visible on-screen.</li><br />
-      <li>A screenshot or picture of the Pokemon summary, displaying the stats and OT/TID of the Pokemon that was obtained. You may use the lua script to confirm the IVs of the Pok&eacute;mon.</li><br />
-      <li>If you did not show the OT/TID screen, you must show a screenshot of your trainer card instead.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
-      <li>For <u>roaming encounters</u>, you must show the frame being hit at the correct screen that the roamer is generated on.</li>
+      <li>For <span class="fw-bold"><u>Encounters</u></span>, a screenshot of the Encounter starting (i.e <code>“Pok&eacute;mon appeared!”</code>).<br />Also for <u>Roaming Encounters</u>, a screenshot of you hitting your target frame at the screen the roamer is generated on.<br />The lua output must be clearly visible on-screen for all screenshots.</li><br />
+      <li>For <span class="fw-bold"><u>Redemptions</u></span>, a screenshot of you hitting your target frame at the screen the Egg/Gift is generated on (i.e <code>“Take good care of it!”</code> or <code>"Would you like to take Pokemon? Y/N"</code> screens respectively).<br />Also a screenshot of the Egg after hatching (i.e <code>“Would you like to nickname...”</code>), or of the Gift mon after Redemption.<br />The lua output must be clearly visible on-screen for all screenshots.</li><br />
+      <li>A screenshot of the Pokemon Summary displaying both the stats and OT/TID of the Pokemon that was obtained (preferred) <u>or</u> your Trainer Card.<br />If an older Lua that doesn't show IVs was used, Summary screenshots <u>are mandatory!</u></li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your Seed and desired target frame along with any other specific configurations used.<br />Sensitive information such as Seeds & PID can be partially
+        blurred on every screenshot (no more than half!).</li><br />
     </ul>
+    We recommend using the most recent Luas for your RNGs so as to show & prove the IVs of your Pok&eacute;mon, in addition to the Seed in the screenshots mentioned above.<br />
     <hr />
 
     <p><span class="fw-bold"><u>For soft resetting and retail RNG abuse you must provide:</u></span></p>
     <ul>
-      <li>A full uncut video starting from a successful capture of your Pok&eacute;mon leading into the in-box summary screens clearly showing the stats, nature, ability, and OT/TID.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
+      <li>A full uncut video starting from a successful capture or redemption of your Pok&eacute;mon, leading into the in-box summary screens clearly showing the Stats, Nature, Ability, and OT/TID.</li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your Seed and desired target frame along with any other specific configurations used.<br />Sensitive information such as Seeds & PID can be partially
+        blurred on every screenshot (no more than half!).</li><br />
     </ul>
 
     <details>
@@ -76,35 +70,11 @@ Pok&eacute;mon has come from.<br /> <br />
         <li><a href="https://imgur.com/a/LsK7uEM">Roaming Encounter</a></li>
       </ul>
     </details>
-  </div>
-</div><br />
-
-<div class="card border-dark">
-  <div class="card-header" style="background-color: #7a298f;" id="gbaegg">
-    <span class="fw-bold text-light">Obtained from Eggs:</span>
-  </div>
-  <div class="card-body card-bg">
-    <p><span class="fw-bold"><u>If you are using emulator with .lua scripts you must provide:</u></span></p>
-    <ul>
-      <li>A screenshot or picture of the target frame being hit (i.e the <code>“Take good care of it!”</code> screen), with the lua output clearly visible on-screen.</li><br />
-      <li>A screenshot or picture of the Pokemon summary, displaying the stats and OT/TID of the Pokemon that was obtained. You may use the lua script to confirm the IVs of the Pok&eacute;mon.</li><br />
-      <li>If you did not show the OT/TID screen, you must show a screenshot of your trainer card instead.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
-    </ul>
-    <hr />
-
-    <p><span class="fw-bold"><u>For soft resetting and retail RNG abuse you must provide:</u></span></p>
-    <ul>
-      <li>A full uncut video starting from a successful egg redemption+hatch, leading into the in-box summary screens clearly showing the stats, nature, ability, and OT/TID.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half!).</li><br />
-    </ul>
-
     <details>
-      <summary><span class="fw-bold">Gen 3 Proof Examples - Egg</span></summary>
+      <summary><span class="fw-bold">Gen 3 Proof Examples - Redemptions</span></summary>
       <ul>
         <li><a href="https://imgur.com/EdOygmr">Egg Redemption</a></li>
+        <li><a href="https://imgur.com/xyHv093">Gift Redemption</a></li>
       </ul>
     </details>
   </div>

--- a/proof-guidelines/GO/index.html
+++ b/proof-guidelines/GO/index.html
@@ -23,9 +23,9 @@ information for the above mentioned games is provided on this page.<br /><br />
 
     <p><span class="fw-bold">All encounter types:</span></p>
     <ul>
-      <li><span class="fw-bold">Shiny Mythical Pok&eacute;mon.</span></li>
-      <li><span class="fw-bold">5 IV+ Shiny Pok&eacute;mon.</span></li>
-      <li><span class="fw-bold">6 IV Legendary/Mythical Pok&eacute;mon.</span></li>
+      <li>Shiny Mythical Pok&eacute;mon.</li>
+      <li>5 IV+ Shiny Pok&eacute;mon.</li>
+      <li>6 IV Legendary/Mythical Pok&eacute;mon.</li>
     </ul>
   </div>
 </div><br />
@@ -36,7 +36,7 @@ information for the above mentioned games is provided on this page.<br /><br />
       style="width:55px;height:55px;">
 </div>
 <hr />
-This section of the page covers how to create proof for Pok&eacute;mon obtained in mobile apps such as HOME and GO. In all cases, your PS! Username <u>must</u> be visible somewhere within your proof link so that we can easily verify exactly where the
+This section of the page covers how to create proof for Pok&eacute;mon obtained in mobile apps such as HOME and GO. In all cases, your <span class="fw-bold">PS! Username <u>must</u> be visible</span> somewhere within your proof link so that we can easily verify exactly where the
 Pok&eacute;mon has come from.<br /> <br />
 
 <div class="card border-dark">
@@ -46,10 +46,10 @@ Pok&eacute;mon has come from.<br /> <br />
   <div class="card-body card-bg">
     <p><span class="fw-bold"><u>You must provide:</u></span></p>
     <ul>
-      <li>A picture of your Pok&eacute;mon GO Username/IGN.</li><br />
-      <li>A picture proving the IVs of the Pok&eacute;mon while in GO. This can be on the main summary page of the Pok&eacute;mon, or a screenshot of a filtered search.</li><br />
-      <li>A picture of the Pok&eacute;mon summary screen in HOME after transfer. This must display matching and accurate IVs (this can be done on HOME Switch or HOME Mobile versions).</u></li><br />
-      <li>A picture of the Pok&eacute;mon OT/TID if not otherwise obvious.</li>
+      <li>A screenshot of your Pok&eacute;mon GO Username/IGN.</li><br />
+      <li>A screenshot proving the IVs of the Pok&eacute;mon while in GO. This can be on the main summary page of the Pok&eacute;mon, or a screenshot of a filtered search.</li><br />
+      <li>A screenshot of the Pok&eacute;mon summary screen in HOME after transfer. This must display matching and accurate IVs (this can be done on HOME Switch or HOME Mobile versions).</u></li><br />
+      <li>A screenshot of the Pok&eacute;mon OT/TID if not otherwise obvious.</li>
     </ul>
 
     <details>

--- a/proof-guidelines/Gamecube/index.html
+++ b/proof-guidelines/Gamecube/index.html
@@ -41,7 +41,7 @@ for the above mentioned games is provided on this page.<br /><br />
       style="width:55px;height:55px;">
 </div>
 <hr />
-This section of the page covers how to create proof for Pok&eacute;mon obtained Colosseum/XD. In all cases, your PS! Username <u>must</u> be visible somewhere within your proof link so that we can easily verify exactly where the Pok&eacute;mon has
+This section of the page covers how to create proof for Pok&eacute;mon obtained Colosseum/XD. In all cases, your <span class="fw-bold">PS! Username <u>must</u> be visible</span> somewhere within your proof link so that we can easily verify exactly where the Pok&eacute;mon has
 come from.<br /> <br />
 
 <div class="card border-dark">
@@ -49,21 +49,21 @@ come from.<br /> <br />
     <span class="fw-bold text-light">Trainer Battles & Gift Encounters:</span>
   </div>
   <div class="card-body card-bg">
-    <p><span class="fw-bold"><u>If you are using emulator with .lua/RAM Watch scripts you must provide:</u></span></p>
+    <p><span class="fw-bold"><u>If using Dolphin or a similar app with .lua/RAM Watch scripts you must provide:</u></span></p>
     <ul>
-      <li>A picture of your trainer card with your current seed on display, along with the RNG tool proving you're close to your target frame (Lua scripts and RAM watches are acceptable).</li><br />
-      <li>A picture in-battle with your target (clearly showing PID if Lua scripts and RAM watches are used).</li><br />
-      <li>A picture of your Pok&eacute;mon summary screen after purification (you may use a Lua script or alternative source to prove the IVs).</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half for the seed!).</li><br />
+      <li>A screenshot of your trainer card with your current seed on display, along with the RNG tool proving you're close to your target frame (Lua scripts and RAM watches are acceptable).</li><br />
+      <li>A screenshot in-battle with your target (clearly showing PID if Lua scripts and RAM watches are used).</li><br />
+      <li>A screenshot of your Pok&eacute;mon summary screen after purification (you may use a Lua script or alternative source to prove the IVs).</li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your Seed and desired target frame along with any other specific configurations used.<br />Sensitive information such as Seeds & PID can be partially
+        blurred on every screenshot (no more than half!).</li><br />
     </ul>
     <hr />
 
     <p><span class="fw-bold"><u>For soft resetting and retail RNG abuse you must provide:</u></span></p>
     <ul>
-      <li>A full uncut video starting from a successful capture of your Pok&eacute;mon leading into the in-box summary screens clearly showing the stats, nature, ability, and OT/TID.</li><br />
-      <li>A screenshot or picture of the tool used to RNG abuse the Pok&eacute;mon. You should show your seed and desired target frame along with any other specific configurations used. Sensitive information such as Seed/PID/EC can be partially
-        blurred (no more than half for the seed!).</li><br />
+      <li>A full uncut video starting from a successful capture or redemption of your Pok&eacute;mon, leading into the in-box summary screens clearly showing the Stats, Nature, Ability, and OT/TID.</li><br />
+      <li>A screenshot of the tool used to RNG abuse the Pok&eacute;mon. You must show your Seed and desired target frame along with any other specific configurations used.<br />Sensitive information such as Seeds & PID can be partially
+        blurred on every screenshot (no more than half!).</li><br />
     </ul>
 
     <details>
@@ -82,7 +82,7 @@ come from.<br /> <br />
       style="width:55px;height:55px;">
 </div>
 <hr />
-This section of the page covers how to create proof for Pok&eacute;mon obtained in GameCube Bonus Discs. In all cases, your PS! Username <u>must</u> be visible somewhere within your proof link so that we can easily verify exactly where the
+This section of the page covers how to create proof for Pok&eacute;mon obtained in GameCube Bonus Discs. In all cases, your <span class="fw-bold">PS! Username <u>must</u> be visible</span> somewhere within your proof link so that we can easily verify exactly where the
 Pok&eacute;mon has come from.<br /> <br />
 
 <div class="card border-dark">
@@ -92,27 +92,27 @@ Pok&eacute;mon has come from.<br /> <br />
   <div class="card-body card-bg">
     <p><span class="fw-bold"><u>For Ageto Celebi you must provide:</u></span></p>
     <ul>
-      <li>A picture of the Celebi redemption screen with your current seed on display, along with the RNG tool proving you are close to your target frame.</li><br />
-      <li>A picture of the Celebi being redeemed and sent to a GBA from the Colosseum Bonus Disc with some identifying information (such as your PS! username) visible.</li><br />
-      <li>A picture of your Celebi summary screens in a Gen 3 game, clearly showing stats and nature (you may use Lua scripts to prove the IVs).</li>
+      <li>A screenshot of the Celebi redemption screen with your current seed on display, along with the RNG tool proving you are close to your target frame.</li><br />
+      <li>A screenshot of the Celebi being redeemed and sent to a GBA from the Colosseum Bonus Disc with some identifying information (such as your PS! username) visible.</li><br />
+      <li>A screenshot of your Celebi summary screens in a Gen 3 game, clearly showing stats and nature (you may use Lua scripts to prove the IVs).</li>
     </ul>
     <hr />
 
     <p><span class="fw-bold"><u>For Wishmaker Jirachi you must provide:</u></span></p>
     <ul>
-      <li>A picture of your current save time with the Wishmaker Jirachi .lua script visible on screen, displaying your seed, delay and target time.</li><br />
-      <li>A picture from a seed searcher (such as Wishmaker-calc or XD Seed) clearly showing that you have a valid rschecksum.</li><br />
-      <li>A picture of the Jirachi being redeemed and sent to a GBA from the Colosseum Bonus Disc with some identifying information (such as your PS! username) visible.</li><br />
-      <li>A picture of your Jirachi summary screens in a Gen 3 game, clearly showing stats and nature (you may use Lua scripts to prove the IVs).</li>
+      <li>A screenshot of your current save time with the Wishmaker Jirachi .lua script visible on screen, displaying your seed, delay and target time.</li><br />
+      <li>A screenshot from a seed searcher (such as Wishmaker-calc or XD Seed) clearly showing that you have a valid rschecksum.</li><br />
+      <li>A screenshot of the Jirachi being redeemed and sent to a GBA from the Colosseum Bonus Disc with some identifying information (such as your PS! username) visible.</li><br />
+      <li>A screenshot of your Jirachi summary screens in a Gen 3 game, clearly showing stats and nature (you may use Lua scripts to prove the IVs).</li>
     </ul>
     <hr />
 
     <p><span class="fw-bold"><u>For Channel Jirachi you must provide:</u></span></p>
     <ul>
-      <li>A picture of the Jirachi “Are you ready?” redemption screen clearly showing your current seed.</li><br />
-      <li>A picture of the RNG tool showing you are close to your target spread along with your current seed, and target frame.</li><br />
-      <li>A picture of the “You got Jirachi!” screen on GBA, clearly showing your RNG tool, desired Jirachi spread, and PS! username on screen.</li><br />
-      <li>A picture of your Jirachi summary screens in a Gen 3 game, clearly showing stats and nature (you may use Lua scripts to prove the IVs).</li>
+      <li>A screenshot of the Jirachi “Are you ready?” redemption screen clearly showing your current seed.</li><br />
+      <li>A screenshot of the RNG tool showing you are close to your target spread along with your current seed, and target frame.</li><br />
+      <li>A screenshot of the “You got Jirachi!” screen on GBA, clearly showing your RNG tool, desired Jirachi spread, and PS! username on screen.</li><br />
+      <li>A screenshot of your Jirachi summary screens in a Gen 3 game, clearly showing stats and nature (you may use Lua scripts to prove the IVs).</li>
     </ul>
 
     <details>

--- a/proof-guidelines/min-requirement/index.html
+++ b/proof-guidelines/min-requirement/index.html
@@ -84,7 +84,7 @@ This section of the page covers the types of Pok&eacute;mon that require proof i
     <span class="fw-bold text-light">All Generations:</span>
   </div>
   <div class="card-body card-bg">
-    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild/Roaming/Stationary encounters:</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Wild/Roaming/Static Encounters & Gift Redemptions:</span></p>
     <u>Encounters with 0 guaranteed IVs</u>
     <ul>
       <li>3 IV+ shiny Pok&eacute;mon</li>
@@ -98,7 +98,7 @@ This section of the page covers the types of Pok&eacute;mon that require proof i
     </ul>
     <hr />
 
-    <p><span class="fw-bold">Pok&eacute;mon obtained from event distributions:</span></p>
+    <p><span class="fw-bold">Pok&eacute;mon obtained from Event Distributions:</span></p>
     <u>Distributions with 0 guaranteed IVs</u>
     <ul>
       <li>4 IV+ non-shiny/shiny Pok&eacute;mon</li>
@@ -114,7 +114,7 @@ This section of the page covers the types of Pok&eacute;mon that require proof i
       <li>"Sometimes shiny" shiny event Pok&eacute;mon</li>
     </ul>
 
-    Note: Event Pok&eacute;mon from Generation 8 games and HOME with fixed values, such as guaranteed 6IV shiny Eternatus or HOME Melmetal, do not need proof.
+    Note: Event Pok&eacute;mon with with fixed values (IVs, Nature, etc), such as guaranteed 6IV shiny Eternatus or HOME Melmetal, do not need proof.
     <hr />
 
     <p><span class="fw-bold">TSV hatched Pok&eacute;mon:</span></p>
@@ -282,7 +282,7 @@ If your Pok&eacute;mon meets the description of anything listed inside above, it
   </div>
   <div class="card-body card-bg">
     <p><span class="fw-bold">This includes:</span> Red/Blue/Green/Yellow & Gold/Silver/Crystal 3DS virtual console releases.</p>
-    <p><span class="fw-bold">All gen 3 titles:</span></p>
+    <p><span class="fw-bold">All gen 1 & 2 titles:</span></p>
     <ul>
       <li>6 IV Pok&eacute;mon from Pok&eacute;Transporter.</li>
       <li>Shiny Pok&eacute;mon of any kind.</li>

--- a/proof-guidelines/virtual-console/index.html
+++ b/proof-guidelines/virtual-console/index.html
@@ -37,7 +37,7 @@ for the above mentioned games is provided on this page.<br /><br />
 </div>
 <hr />
 
-This section of the page covers how to create proof for Pok&eacute;mon obtained in Virtual Console titles. In all cases, your PS! Username <u>must</u> be visible somewhere within your proof link so that we can easily verify exactly where the
+This section of the page covers how to create proof for Pok&eacute;mon obtained in Virtual Console titles. In all cases, your <span class="fw-bold">PS! Username <u>must</u> be visible</span> somewhere within your proof link so that we can easily verify exactly where the
 Pok&eacute;mon has come from.<br /> <br />
 
 <div class="card border-dark">
@@ -47,13 +47,13 @@ Pok&eacute;mon has come from.<br /> <br />
   <div class="card-body card-bg">
     <p><span class="fw-bold"><u>You must provide:</u></span></p>
     <ul>
-      <li>[Wild Encounter] A picture during an encounter with the Pok&eacute;mon during the “Player threw the ball” OR “Pok&eacute;mon Appeared” text box, with a paper slip showing your PS! Username.</li>
-      <li>[Egg / Gift Encounter] A picture during the egg hatch/gift redemption screen with a paper slip showing your PS! Username.</li>
+      <li>For <u>Wild Encounters</u> a picture of the Encounter with the Pok&eacute;mon during the <code>“Player threw the ball”</code> OR <code>“Pok&eacute;mon Appeared”</code> text box, with a paper slip showing your PS! Username.</li>
+      <li>For <u>Egg Hatch & Gift Redemptions</u> a picture during the Egg Hatch/Gift Redemption screen with a paper slip showing your PS! Username.</li>
       <li>A picture of the Pok&eacute;mon summary, clearly showing your OT/TID if not otherwise shown.</li>
-      <li>If the Pok&eacute;mon was RNG abused with Pok&eacute;Transporter, show screenshots of the RNG tool and pcalc overlay used in order to verify this. Sensitive information such as Seed/PID/EC can be partially blurred (no more than half!).
+      <li>If the Pok&eacute;mon was RNG abused with Pok&eacute;Transporter, show screenshots of the RNG tool and pcalc overlay used in order to verify this.<br />Sensitive information such as Seeds/PID/EC can be partially blurred (no more than half!).
 </li>
-      <li>If the Pok&eacute;mon is a shiny from Gen 1, show it in the Pok&eacute;Transporter box waiting to be picked up.</li>
-      <li>If your Pok&eacute;mon was obtained by use of an emulator, you may watermark your images instead of providing a picture with a paper slip.</li>
+      <li>If the Pok&eacute;mon is a shiny from Gen 1, you must show it in the Pok&eacute;Transporter box waiting to be picked up.</li>
+      <li>If your Pok&eacute;mon was obtained by use of VBA or another similar app, you may watermark your screenshots instead of providing a picture with a paper slip.</li>
     </ul>
 
     <details>


### PR DESCRIPTION
Main changes:
- Overhaul of GBA, DS & 3DS proof requirements pages, condensing them into more easily readable and understandable topics.
- Standardization of proof requirements across Gens 3 to 7, requiring now the same types of screenshots required across them all.
- Added proof examples for virtually every single type of RNG users might tackle across each one of this generations

Minor changes:
- Changed wording on GameCube, VirtualConsole and POGO proof requirement pages to better align (and standardize terms) with the changes made on the GBA, DS & 3DS pages
- Minor wording changes to the main "minimum requirements" page