### PR TITLE
tournaments WP - Loe

### DIFF
--- a/events/tournaments/index.html
+++ b/events/tournaments/index.html
@@ -89,9 +89,9 @@ in competitive battling, you won't want to miss them!<br /><br />
       <li><span class="fw-bold">In-game Monthly Tours</span> &mdash; Winner: 75 WP runner-up: 40 WP, semi-finalist: 30 WP, quarter-finalist: 20 WP, all other participants: 10 WP.</li><br />
       <li><span class="fw-bold">Nugget Bridge</span> &mdash; Winning a battle: 6 WP, Losing a battle: 3 WP. There is a soft cap of 75 WP. Winning a battle while capped: 3 WP, Losing a battle while capped: 1 WP.</li><br />
       <li><span class="fw-bold">Nugget Bridge Breakpoints</span> &mdash; Hitting a certain amount of WP during a Nugget Bridge cycle will allow for bonus amounts to be added! At 12 WP: 6 WP extra, 30 WP: 7 WP extra, and 61 WP: 14 WP extra.</li><br />
-      <li><span class="fw-bold">Bonus prizes!</span> &mdash; The winner of the monthly tournament can choose a bonus prize consisting of a 100 WP Pok&eacute;mon from the prize shop, or a custom RNG of similar value! The top-placing player of the Nugget Bridge becomes roomprizewinner (<code>^</code>) rank for a week!</code></li>
+      <li><span class="fw-bold">Bonus prizes!</span> &mdash; The winner of the monthly tournament can choose a bonus prize consisting of a 125 WP Pok&eacute;mon from the prize shop, or a custom RNG of similar value! The top-placing player of the Nugget Bridge becomes roomprizewinner (<code>^</code>) rank for a week!</code></li>
       <ul>
-        <li>Note: Custom RNGs are subject to helper availability and are limited to eggs (6IV) or event (5IV).</li>
+        <li>Note: Custom RNGs are subject to helper availability and are limited to eggs (6IV) or event (6IV).</li>
       </ul>
     </ul>
   </div>

--- a/events/tournaments/index.html
+++ b/events/tournaments/index.html
@@ -85,8 +85,8 @@ in competitive battling, you won't want to miss them!<br /><br />
     <p><span class="fw-bold">Wi-Fi Points (WP)</span> can be used in the Wi-Fi Prize shop and can be earned through all avenues of tournament participation. Check out what you could be earning!</p>
     <ul>
       <li><span class="fw-bold">Daily Simtours</span> &mdash; Winner: 3 WP, runner-up: 2 WP, semi-finalist: 1 WP.</li><br />
-      <li><span class="fw-bold">In-game Practice Tours</span> &mdash; Winner: 20 WP runner-up: 15 WP, semi-finalist: 10 WP, all other participants: 5 WP.</li><br />
-      <li><span class="fw-bold">In-game Monthly Tours</span> &mdash; Winner: 60 WP runner-up: 40 WP, semi-finalist: 30 WP, quarter-finalist: 20 WP, all other participants: 10 WP.</li><br />
+      <li><span class="fw-bold">In-game Practice Tours</span> &mdash; Winner: 30 WP runner-up: 15 WP, semi-finalist: 10 WP, all other participants: 5 WP.</li><br />
+      <li><span class="fw-bold">In-game Monthly Tours</span> &mdash; Winner: 75 WP runner-up: 40 WP, semi-finalist: 30 WP, quarter-finalist: 20 WP, all other participants: 10 WP.</li><br />
       <li><span class="fw-bold">Nugget Bridge</span> &mdash; Winning a battle: 6 WP, Losing a battle: 3 WP. There is a soft cap of 75 WP. Winning a battle while capped: 3 WP, Losing a battle while capped: 1 WP.</li><br />
       <li><span class="fw-bold">Nugget Bridge Breakpoints</span> &mdash; Hitting a certain amount of WP during a Nugget Bridge cycle will allow for bonus amounts to be added! At 12 WP: 6 WP extra, 30 WP: 7 WP extra, and 61 WP: 14 WP extra.</li><br />
       <li><span class="fw-bold">Bonus prizes!</span> &mdash; The winner of the monthly tournament can choose a bonus prize consisting of a 100 WP Pok&eacute;mon from the prize shop, or a custom RNG of similar value! The top-placing player of the Nugget Bridge becomes roomprizewinner (<code>^</code>) rank for a week!</code></li>


### PR DESCRIPTION
Increased the winner's WP at lines 88 & 89, increased the WP prize range for monthly winners at line 92, increased the upper IV limit on Custom RNGs on line 94 to 6iv event